### PR TITLE
feat: delete efs folder for service (SKY_HOME) once it is terminated

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -327,7 +327,7 @@ def setup_lambda_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     # controller, i.e., the public and private key on the node may
     # not match.
     file_mounts = config['file_mounts']
-    file_mounts[PUBLIC_SSH_KEY_PATH] = REMOTE_PUBLIC_SSH_KEY_PATH
+    file_mounts[REMOTE_PUBLIC_SSH_KEY_PATH] = PUBLIC_SSH_KEY_PATH
     config['file_mounts'] = file_mounts
 
     return config
@@ -385,7 +385,7 @@ def setup_ibm_authentication(config):
 
     # Add public key path to file mounts
     file_mounts = config['file_mounts']
-    file_mounts[PUBLIC_SSH_KEY_PATH] = REMOTE_PUBLIC_SSH_KEY_PATH
+    file_mounts[REMOTE_PUBLIC_SSH_KEY_PATH] = PUBLIC_SSH_KEY_PATH
     config['file_mounts'] = file_mounts
 
     return config

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -320,7 +320,7 @@ def setup_lambda_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
 
     # Need to use ~ relative path because Ray uses the same
     # path for finding the public key path on both local and head node.
-    config['auth']['ssh_public_key'] = PUBLIC_SSH_KEY_PATH
+    config['auth']['ssh_public_key'] = REMOTE_PUBLIC_SSH_KEY_PATH
 
     # TODO(zhwu): we need to avoid uploading the public ssh key to the
     # nodes, as that will cause problem when the node is used as spot

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -45,6 +45,7 @@ from sky.adaptors import ibm
 from sky.adaptors import kubernetes
 from sky.adaptors import runpod
 from sky.clouds.utils import lambda_utils
+from sky.constants import SKY_HOME
 from sky.provision.fluidstack import fluidstack_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import common_utils
@@ -61,9 +62,11 @@ logger = sky_logging.init_logger(__name__)
 
 MAX_TRIALS = 64
 # TODO(zhwu): Support user specified key pair.
-PRIVATE_SSH_KEY_PATH = '~/.ssh/sky-key'
-PUBLIC_SSH_KEY_PATH = '~/.ssh/sky-key.pub'
-_SSH_KEY_GENERATION_LOCK = '~/.sky/generated/ssh/.__internal-sky-key.lock'
+
+_SSH_KEY_GENERATION_LOCK = f'{SKY_HOME}/generated/ssh/.__internal-sky-key.lock'
+SSH_DIR = os.environ.get('SKY_HOME', '~/.ssh')
+PRIVATE_SSH_KEY_PATH = f'{SSH_DIR}/sky-key'
+PUBLIC_SSH_KEY_PATH = f'{SSH_DIR}/sky-key.pub'
 
 
 def _generate_rsa_key_pair() -> Tuple[str, str]:

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -67,6 +67,7 @@ _SSH_KEY_GENERATION_LOCK = f'{SKY_HOME}/generated/ssh/.__internal-sky-key.lock'
 SSH_DIR = os.environ.get('SKY_HOME', '~/.ssh')
 PRIVATE_SSH_KEY_PATH = f'{SSH_DIR}/sky-key'
 PUBLIC_SSH_KEY_PATH = f'{SSH_DIR}/sky-key.pub'
+REMOTE_PUBLIC_SSH_KEY_PATH = '~/.ssh/sky-key.pub'
 
 
 def _generate_rsa_key_pair() -> Tuple[str, str]:
@@ -326,7 +327,7 @@ def setup_lambda_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     # controller, i.e., the public and private key on the node may
     # not match.
     file_mounts = config['file_mounts']
-    file_mounts[PUBLIC_SSH_KEY_PATH] = PUBLIC_SSH_KEY_PATH
+    file_mounts[PUBLIC_SSH_KEY_PATH] = REMOTE_PUBLIC_SSH_KEY_PATH
     config['file_mounts'] = file_mounts
 
     return config
@@ -384,7 +385,7 @@ def setup_ibm_authentication(config):
 
     # Add public key path to file mounts
     file_mounts = config['file_mounts']
-    file_mounts[PUBLIC_SSH_KEY_PATH] = PUBLIC_SSH_KEY_PATH
+    file_mounts[PUBLIC_SSH_KEY_PATH] = REMOTE_PUBLIC_SSH_KEY_PATH
     config['file_mounts'] = file_mounts
 
     return config

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -807,7 +807,13 @@ def write_cluster_config(
                 'is not supported by this cloud. Remove the config or set: '
                 '`remote_identity: LOCAL_CREDENTIALS`.')
         excluded_clouds = [cloud]
-    credentials = sky_check.get_cloud_credential_file_mounts(excluded_clouds)
+
+    # this environment variable decides if we want to authenticate the remote task
+    # with the user's clouds
+    if os.environ.get('SKYPILOT_DISABLE_REMOTE_TASK_AUTHENTICATION', '').strip() == '1':
+        credentials = {}
+    else:
+        credentials = sky_check.get_cloud_credential_file_mounts(excluded_clouds)
 
     auth_config = {'ssh_private_key': auth.PRIVATE_SSH_KEY_PATH}
     region_name = resources_vars.get('region')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -62,17 +62,17 @@ if typing.TYPE_CHECKING:
 logger = sky_logging.init_logger(__name__)
 
 # NOTE: keep in sync with the cluster template 'file_mounts'.
-SKY_REMOTE_APP_DIR = '~/sky/sky_app'
+SKY_REMOTE_APP_DIR = '~/.sky/sky_app'
 # Exclude subnet mask from IP address regex.
 IP_ADDR_REGEX = r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?!/\d{1,2})\b'
-SKY_REMOTE_PATH = '~/sky/wheels'
+SKY_REMOTE_PATH = '~/.sky/wheels'
 SKY_USER_FILE_PATH = f'{SKY_HOME}/generated'
 
 BOLD = '\033[1m'
 RESET_BOLD = '\033[0m'
 
 # Do not use /tmp because it gets cleared on VM restart.
-_SKY_REMOTE_FILE_MOUNTS_DIR = '~/sky/file_mounts/'
+_SKY_REMOTE_FILE_MOUNTS_DIR = '~/.sky/file_mounts/'
 
 _LAUNCHED_HEAD_PATTERN = re.compile(r'(\d+) ray[._]head[._]default')
 _LAUNCHED_LOCAL_WORKER_PATTERN = re.compile(r'(\d+) node_')
@@ -107,7 +107,7 @@ CLUSTER_FILE_MOUNTS_LOCK_PATH = os.path.expanduser(
 CLUSTER_FILE_MOUNTS_LOCK_TIMEOUT_SECONDS = 10
 
 # Remote dir that holds our runtime files.
-_REMOTE_RUNTIME_FILES_DIR = '~/sky/.runtime_files'
+_REMOTE_RUNTIME_FILES_DIR = '~/.sky/.runtime_files'
 
 # Include the fields that will be used for generating tags that distinguishes
 # the cluster in ray, to avoid the stopped cluster being discarded due to

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -389,7 +389,7 @@ class FileMountHelper(object):
 class SSHConfigHelper(object):
     """Helper for handling local SSH configuration."""
 
-    ssh_conf_path = '~/.ssh/config'
+    ssh_conf_path = f'{os.environ.get("SKY_HOME", "~/.ssh")}/config'
     ssh_conf_lock_path = os.path.expanduser(f'{SKY_HOME}/ssh_config.lock')
     ssh_cluster_path = SKY_USER_FILE_PATH + '/ssh/{}'
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -62,17 +62,17 @@ if typing.TYPE_CHECKING:
 logger = sky_logging.init_logger(__name__)
 
 # NOTE: keep in sync with the cluster template 'file_mounts'.
-SKY_REMOTE_APP_DIR = f'{SKY_HOME}/sky_app'
+SKY_REMOTE_APP_DIR = '~/sky/sky_app'
 # Exclude subnet mask from IP address regex.
 IP_ADDR_REGEX = r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?!/\d{1,2})\b'
-SKY_REMOTE_PATH = f'{SKY_HOME}/wheels'
+SKY_REMOTE_PATH = '~/sky/wheels'
 SKY_USER_FILE_PATH = f'{SKY_HOME}/generated'
 
 BOLD = '\033[1m'
 RESET_BOLD = '\033[0m'
 
 # Do not use /tmp because it gets cleared on VM restart.
-_SKY_REMOTE_FILE_MOUNTS_DIR = f'{SKY_HOME}/file_mounts/'
+_SKY_REMOTE_FILE_MOUNTS_DIR = '~/sky/file_mounts/'
 
 _LAUNCHED_HEAD_PATTERN = re.compile(r'(\d+) ray[._]head[._]default')
 _LAUNCHED_LOCAL_WORKER_PATTERN = re.compile(r'(\d+) node_')
@@ -107,7 +107,7 @@ CLUSTER_FILE_MOUNTS_LOCK_PATH = os.path.expanduser(
 CLUSTER_FILE_MOUNTS_LOCK_TIMEOUT_SECONDS = 10
 
 # Remote dir that holds our runtime files.
-_REMOTE_RUNTIME_FILES_DIR = f'{SKY_HOME}/.runtime_files'
+_REMOTE_RUNTIME_FILES_DIR = '~/sky/.runtime_files'
 
 # Include the fields that will be used for generating tags that distinguishes
 # the cluster in ray, to avoid the stopped cluster being discarded due to

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -38,6 +38,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky import status_lib
 from sky.clouds import cloud_registry
+from sky.constants import SKY_HOME
 from sky.provision import instance_setup
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.skylet import constants
@@ -61,17 +62,17 @@ if typing.TYPE_CHECKING:
 logger = sky_logging.init_logger(__name__)
 
 # NOTE: keep in sync with the cluster template 'file_mounts'.
-SKY_REMOTE_APP_DIR = '~/.sky/sky_app'
+SKY_REMOTE_APP_DIR = f'{SKY_HOME}/sky_app'
 # Exclude subnet mask from IP address regex.
 IP_ADDR_REGEX = r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?!/\d{1,2})\b'
-SKY_REMOTE_PATH = '~/.sky/wheels'
-SKY_USER_FILE_PATH = '~/.sky/generated'
+SKY_REMOTE_PATH = f'{SKY_HOME}/wheels'
+SKY_USER_FILE_PATH = f'{SKY_HOME}/generated'
 
 BOLD = '\033[1m'
 RESET_BOLD = '\033[0m'
 
 # Do not use /tmp because it gets cleared on VM restart.
-_SKY_REMOTE_FILE_MOUNTS_DIR = '~/.sky/file_mounts/'
+_SKY_REMOTE_FILE_MOUNTS_DIR = f'{SKY_HOME}/file_mounts/'
 
 _LAUNCHED_HEAD_PATTERN = re.compile(r'(\d+) ray[._]head[._]default')
 _LAUNCHED_LOCAL_WORKER_PATTERN = re.compile(r'(\d+) node_')
@@ -97,16 +98,16 @@ _TEST_IP_LIST = ['https://1.1.1.1', 'https://8.8.8.8']
 DEFAULT_TASK_CPU_DEMAND = 0.5
 
 # Filelocks for the cluster status change.
-CLUSTER_STATUS_LOCK_PATH = os.path.expanduser('~/.sky/.{}.lock')
+CLUSTER_STATUS_LOCK_PATH = os.path.expanduser(f'{SKY_HOME}/.{{}}.lock')
 CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS = 20
 
 # Filelocks for updating cluster's file_mounts.
 CLUSTER_FILE_MOUNTS_LOCK_PATH = os.path.expanduser(
-    '~/.sky/.{}_file_mounts.lock')
+    f'{SKY_HOME}/.{{}}_file_mounts.lock')
 CLUSTER_FILE_MOUNTS_LOCK_TIMEOUT_SECONDS = 10
 
 # Remote dir that holds our runtime files.
-_REMOTE_RUNTIME_FILES_DIR = '~/.sky/.runtime_files'
+_REMOTE_RUNTIME_FILES_DIR = f'{SKY_HOME}/.runtime_files'
 
 # Include the fields that will be used for generating tags that distinguishes
 # the cluster in ray, to avoid the stopped cluster being discarded due to
@@ -389,7 +390,7 @@ class SSHConfigHelper(object):
     """Helper for handling local SSH configuration."""
 
     ssh_conf_path = '~/.ssh/config'
-    ssh_conf_lock_path = os.path.expanduser('~/.sky/ssh_config.lock')
+    ssh_conf_lock_path = os.path.expanduser(f'{SKY_HOME}/ssh_config.lock')
     ssh_cluster_path = SKY_USER_FILE_PATH + '/ssh/{}'
 
     @classmethod

--- a/sky/benchmark/benchmark_state.py
+++ b/sky/benchmark/benchmark_state.py
@@ -9,13 +9,15 @@ import time
 import typing
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
+from sky.constants import SKY_HOME
+
 if typing.TYPE_CHECKING:
     from sky.backends import backend as backend_lib
 
 _BENCHMARK_BUCKET_NAME_KEY = 'bucket_name'
 _BENCHMARK_BUCKET_TYPE_KEY = 'bucket_type'
 
-_BENCHMARK_DB_PATH = os.path.expanduser('~/.sky/benchmark.db')
+_BENCHMARK_DB_PATH = os.path.expanduser(f'{SKY_HOME}/benchmark.db')
 os.makedirs(pathlib.Path(_BENCHMARK_DB_PATH).parents[0], exist_ok=True)
 
 

--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -43,7 +43,7 @@ if typing.TYPE_CHECKING:
 logger = sky_logging.init_logger(__name__)
 
 _SKY_LOCAL_BENCHMARK_DIR = os.path.expanduser(f'{SKY_HOME}/benchmarks')
-_SKY_REMOTE_BENCHMARK_DIR = '~/sky/sky_benchmark_dir'
+_SKY_REMOTE_BENCHMARK_DIR = '~/.sky/sky_benchmark_dir'
 # NOTE: This must be the same as _SKY_REMOTE_BENCHMARK_DIR
 # in sky/callbacks/sky_callback/base.py.
 _SKY_REMOTE_BENCHMARK_DIR_SYMLINK = '~/sky_benchmark_dir'

--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -27,6 +27,7 @@ from sky import status_lib
 from sky.backends import backend_utils
 from sky.benchmark import benchmark_state
 from sky.data import storage as storage_lib
+from sky.constants import SKY_HOME
 from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.skylet import log_lib
@@ -41,8 +42,8 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
-_SKY_LOCAL_BENCHMARK_DIR = os.path.expanduser('~/.sky/benchmarks')
-_SKY_REMOTE_BENCHMARK_DIR = '~/.sky/sky_benchmark_dir'
+_SKY_LOCAL_BENCHMARK_DIR = os.path.expanduser(f'{SKY_HOME}/benchmarks')
+_SKY_REMOTE_BENCHMARK_DIR = f'{SKY_HOME}/sky_benchmark_dir'
 # NOTE: This must be the same as _SKY_REMOTE_BENCHMARK_DIR
 # in sky/callbacks/sky_callback/base.py.
 _SKY_REMOTE_BENCHMARK_DIR_SYMLINK = '~/sky_benchmark_dir'

--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -43,7 +43,7 @@ if typing.TYPE_CHECKING:
 logger = sky_logging.init_logger(__name__)
 
 _SKY_LOCAL_BENCHMARK_DIR = os.path.expanduser(f'{SKY_HOME}/benchmarks')
-_SKY_REMOTE_BENCHMARK_DIR = f'{SKY_HOME}/sky_benchmark_dir'
+_SKY_REMOTE_BENCHMARK_DIR = '~/sky/sky_benchmark_dir'
 # NOTE: This must be the same as _SKY_REMOTE_BENCHMARK_DIR
 # in sky/callbacks/sky_callback/base.py.
 _SKY_REMOTE_BENCHMARK_DIR_SYMLINK = '~/sky_benchmark_dir'

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -81,6 +81,10 @@ class AWSIdentityType(enum.Enum):
 
     IAM_ROLE = 'iam-role'
 
+    ASSUME_ROLE = 'assume-role'
+
+    ASSUME_ROLE_WITH_WEB_IDENTITY = 'assume-role-with-web-identity'
+
     #       Name                    Value             Type    Location
     #       ----                    -----             ----    --------
     #    profile                <not set>             None    None
@@ -606,6 +610,10 @@ class AWS(clouds.Cloud):
             return AWSIdentityType.IAM_ROLE
         elif _is_access_key_of_type(AWSIdentityType.ENV.value):
             return AWSIdentityType.ENV
+        elif _is_access_key_of_type(AWSIdentityType.ASSUME_ROLE_WITH_WEB_IDENTITY.value):
+            return AWSIdentityType.ASSUME_ROLE_WITH_WEB_IDENTITY
+        elif _is_access_key_of_type(AWSIdentityType.ASSUME_ROLE.value):
+            return AWSIdentityType.ASSUME_ROLE
         else:
             return AWSIdentityType.SHARED_CREDENTIALS_FILE
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -545,7 +545,7 @@ class AWS(clouds.Cloud):
             # created by an SSO account, i.e. the VM will be assigned the IAM
             # role: skypilot-v1.
             hints = f'AWS IAM role is set.{single_cloud_hint}'
-        else:
+        elif identity_type is None:
             # This file is required because it is required by the VMs launched on
             # other clouds to access private s3 buckets and resources like EC2.
             # `get_current_user_identity` does not guarantee this file exists.

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -17,6 +17,7 @@ from sky import sky_logging
 from sky.adaptors import gcp
 from sky.clouds import service_catalog
 from sky.clouds.utils import gcp_utils
+from sky.constants import SKY_HOME
 from sky.utils import common_utils
 from sky.utils import resources_utils
 from sky.utils import subprocess_utils
@@ -57,7 +58,7 @@ _CREDENTIAL_FILES = [
 
 # NOTE: do not expanduser() on this path. It's used as a destination path on the
 # remote cluster.
-_GCLOUD_INSTALLATION_LOG = '~/.sky/logs/gcloud_installation.log'
+_GCLOUD_INSTALLATION_LOG = f'{SKY_HOME}/logs/gcloud_installation.log'
 _GCLOUD_VERSION = '424.0.0'
 # Need to be run with /bin/bash
 # We factor out the installation logic to keep it align in both spot

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -9,6 +9,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import kubernetes
 from sky.clouds import service_catalog
+from sky.constants import SKY_HOME
 from sky.provision.kubernetes import network_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import common_utils
@@ -35,7 +36,7 @@ class Kubernetes(clouds.Cloud):
     SKY_SSH_JUMP_NAME = 'sky-ssh-jump-pod'
     PORT_FORWARD_PROXY_CMD_TEMPLATE = \
         'kubernetes-port-forward-proxy-command.sh.j2'
-    PORT_FORWARD_PROXY_CMD_PATH = '~/.sky/port-forward-proxy-cmd.sh'
+    PORT_FORWARD_PROXY_CMD_PATH = f'{SKY_HOME}/port-forward-proxy-cmd.sh'
     # Timeout for resource provisioning. This timeout determines how long to
     # wait for pod to be in pending status before giving up.
     # Larger timeout may be required for autoscaling clusters, since autoscaler

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -44,7 +44,7 @@ class Lambda(clouds.Cloud):
         clouds.CloudImplementationFeatures.SPOT_INSTANCE: f'Spot instances are not supported in {_REPR}.',
         clouds.CloudImplementationFeatures.IMAGE_ID: f'Specifying image ID is not supported in {_REPR}.',
         clouds.CloudImplementationFeatures.CUSTOM_DISK_TIER: f'Custom disk tiers are not supported in {_REPR}.',
-        clouds.CloudImplementationFeatures.OPEN_PORTS: f'Opening ports is currently not supported on {_REPR}.',
+        # clouds.CloudImplementationFeatures.OPEN_PORTS: f'Opening ports is currently not supported on {_REPR}.',
     }
 
     @classmethod

--- a/sky/clouds/service_catalog/constants.py
+++ b/sky/clouds/service_catalog/constants.py
@@ -1,7 +1,11 @@
+import os
+
+from sky.constants import SKY_HOME
+
 """Constants used for service catalog."""
 HOSTED_CATALOG_DIR_URL = 'https://raw.githubusercontent.com/skypilot-org/skypilot-catalog/master/catalogs'  # pylint: disable=line-too-long
 CATALOG_SCHEMA_VERSION = 'v5'
-CATALOG_DIR = '~/.sky/catalogs'
+CATALOG_DIR = os.path.expanduser(f'{SKY_HOME}/catalogs/')
 ALL_CLOUDS = ('aws', 'azure', 'gcp', 'ibm', 'lambda', 'scp', 'oci',
               'kubernetes', 'runpod', 'vsphere', 'cudo', 'fluidstack',
               'paperspace')

--- a/sky/clouds/utils/lambda_utils.py
+++ b/sky/clouds/utils/lambda_utils.py
@@ -122,13 +122,17 @@ class LambdaCloudClient:
 
     def __init__(self) -> None:
         self.credentials = os.path.expanduser(CREDENTIALS_PATH)
-        assert os.path.exists(self.credentials), 'Credentials not found'
-        with open(self.credentials, 'r', encoding='utf-8') as f:
-            lines = [line.strip() for line in f.readlines() if ' = ' in line]
-            self._credentials = {
-                line.split(' = ')[0]: line.split(' = ')[1] for line in lines
-            }
-        self.api_key = self._credentials['api_key']
+        if os.path.isfile(self.credentials):
+            with open(self.credentials, 'r', encoding='utf-8') as f:
+                lines = [line.strip() for line in f.readlines() if ' = ' in line]
+                self._credentials = {
+                    line.split(' = ')[0]: line.split(' = ')[1] for line in lines
+                }
+            self.api_key = self._credentials['api_key']
+        else:
+            api_key = os.environ.get('LAMBDA_LABS_API_KEY', None)
+            assert api_key, 'Credentials not found'
+            self.api_key = api_key
         self.headers = {'Authorization': f'Bearer {self.api_key}'}
 
     def create_instances(self,

--- a/sky/constants.py
+++ b/sky/constants.py
@@ -1,0 +1,3 @@
+import os
+
+SKY_HOME = os.environ.get('SKY_HOME', '~/.sky')

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -4,6 +4,7 @@ import textwrap
 from typing import Optional
 
 from sky import exceptions
+from sky.constants import SKY_HOME
 
 # Values used to construct mounting commands
 _STAT_CACHE_TTL = '5s'
@@ -206,7 +207,7 @@ def get_mounting_command(
 
     # While these commands are run sequentially for each storage object,
     # we add random int to be on the safer side and avoid collisions.
-    script_path = f'~/.sky/mount_{random.randint(0, 1000000)}.sh'
+    script_path = f'{SKY_HOME}/mount_{random.randint(0, 1000000)}.sh'
     first_line = r'(cat <<-\EOF > {}'.format(script_path)
     command = (f'{first_line}'
                f'{script}'

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -207,7 +207,7 @@ def get_mounting_command(
 
     # While these commands are run sequentially for each storage object,
     # we add random int to be on the safer side and avoid collisions.
-    script_path = f'{SKY_HOME}/mount_{random.randint(0, 1000000)}.sh'
+    script_path = f'~/sky/mount_{random.randint(0, 1000000)}.sh'
     first_line = r'(cat <<-\EOF > {}'.format(script_path)
     command = (f'{first_line}'
                f'{script}'

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -207,7 +207,7 @@ def get_mounting_command(
 
     # While these commands are run sequentially for each storage object,
     # we add random int to be on the safer side and avoid collisions.
-    script_path = f'~/sky/mount_{random.randint(0, 1000000)}.sh'
+    script_path = f'~/.sky/mount_{random.randint(0, 1000000)}.sh'
     first_line = r'(cat <<-\EOF > {}'.format(script_path)
     command = (f'{first_line}'
                f'{script}'

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -18,6 +18,7 @@ import uuid
 
 from sky import clouds
 from sky import status_lib
+from sky.constants import SKY_HOME
 from sky.utils import common_utils
 from sky.utils import db_utils
 
@@ -27,7 +28,7 @@ if typing.TYPE_CHECKING:
 
 _ENABLED_CLOUDS_KEY = 'enabled_clouds'
 
-_DB_PATH = os.path.expanduser('~/.sky/state.db')
+_DB_PATH = os.path.expanduser(f'{SKY_HOME}/state.db')
 pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
 
 

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -21,6 +21,7 @@ from sky.provision import gcp
 from sky.provision import kubernetes
 from sky.provision import runpod
 from sky.provision import vsphere
+from sky.provision import lambda_cloud
 
 logger = sky_logging.init_logger(__name__)
 
@@ -38,6 +39,8 @@ def _route_to_cloud_impl(func):
             provider_name = kwargs.pop('provider_name')
 
         module_name = provider_name.lower()
+        if module_name == 'lambda':
+            module_name = 'lambda_cloud'
         module = globals().get(module_name)
         assert module is not None, f'Unknown provider: {module_name}'
 

--- a/sky/provision/lambda_cloud/__init__.py
+++ b/sky/provision/lambda_cloud/__init__.py
@@ -1,0 +1,5 @@
+"""Lambda provisioner for SkyPilot."""
+
+from sky.provision.lambda_cloud.instance import cleanup_ports
+from sky.provision.lambda_cloud.instance import open_ports
+from sky.provision.lambda_cloud.instance import query_ports

--- a/sky/provision/lambda_cloud/instance.py
+++ b/sky/provision/lambda_cloud/instance.py
@@ -1,0 +1,35 @@
+"""Lambda instance provisioning."""
+from typing import Any, Dict, List, Optional
+
+from sky.provision import common
+
+
+
+def open_ports(
+    cluster_name_on_cloud: str,
+    ports: List[str],
+    provider_config: Optional[Dict[str, Any]] = None,
+) -> None:
+    # Do nothing because we assume the user has updated their firewall
+    # rules to allow these ports
+    pass
+
+def cleanup_ports(
+    cluster_name_on_cloud: str,
+    ports: List[str],
+    provider_config: Optional[Dict[str, Any]] = None,
+) -> None:
+    """See sky/provision/__init__.py"""
+    # Azure will automatically cleanup network security groups when cleanup
+    # resource group. So we don't need to do anything here.
+    del cluster_name_on_cloud, ports, provider_config  # Unused.
+
+
+def query_ports(
+    cluster_name_on_cloud: str,
+    ports: List[str],
+    provider_config: Optional[Dict[str, Any]] = None,
+) -> Dict[int, List[common.Endpoint]]:
+    """See sky/provision/__init__.py"""
+    return common.query_ports_passthrough(cluster_name_on_cloud, ports,
+                                          provider_config)

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -5,6 +5,7 @@ import os
 CONTROLLER_TEMPLATE = 'sky-serve-controller.yaml.j2'
 
 SKYSERVE_METADATA_DIR = f'{SKY_HOME}/serve'
+LOGS_DIR = f'{SKY_HOME}/sky_logs'
 
 # The filelock for selecting service ports on controller VM when starting a
 # service. We need to have a filelock to avoid port collision when starting

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -1,5 +1,6 @@
 """Constants used for SkyServe."""
 from sky.constants import SKY_HOME
+import os
 
 CONTROLLER_TEMPLATE = 'sky-serve-controller.yaml.j2'
 
@@ -11,7 +12,7 @@ SKYSERVE_METADATA_DIR = f'{SKY_HOME}/serve'
 PORT_SELECTION_FILE_LOCK_PATH = f'{SKYSERVE_METADATA_DIR}/port_selection.lock'
 
 # Signal file path for controller to handle signals.
-SIGNAL_FILE_PATH = '/tmp/sky_serve_controller_signal_{}'
+SIGNAL_FILE_PATH = os.path.join(SKY_HOME, 'serve', 'sky_serve_controller_signal_{}')
 
 # Time to wait in seconds for service to register on the controller.
 SERVICE_REGISTER_TIMEOUT_SECONDS = 60
@@ -68,7 +69,7 @@ DEFAULT_MIN_REPLICAS = 1
 
 # Default port range start for controller and load balancer. Ports will be
 # automatically generated from this start port.
-CONTROLLER_PORT_START = 20001
+CONTROLLER_PORT_START = 8000
 LOAD_BALANCER_PORT_START = 30001
 LOAD_BALANCER_PORT_RANGE = '30001-30100'
 

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -1,8 +1,9 @@
 """Constants used for SkyServe."""
+from sky.constants import SKY_HOME
 
 CONTROLLER_TEMPLATE = 'sky-serve-controller.yaml.j2'
 
-SKYSERVE_METADATA_DIR = '~/.sky/serve'
+SKYSERVE_METADATA_DIR = f'{SKY_HOME}/serve'
 
 # The filelock for selecting service ports on controller VM when starting a
 # service. We need to have a filelock to avoid port collision when starting

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -150,9 +150,9 @@ class SkyServeController:
         threading.Thread(target=self._run_autoscaler).start()
 
         logger.info('SkyServe Controller started on '
-                    f'http://localhost:{self._port}')
+                    f'http://0.0.0.0:{self._port}')
 
-        uvicorn.run(self._app, host='localhost', port=self._port)
+        uvicorn.run(self._app, host='0.0.0.0', port=self._port)
 
 
 # TODO(tian): Probably we should support service that will stop the VM in

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -93,6 +93,8 @@ class SkyServeLoadBalancer:
             request_url_path_without_service_id = request_url_path[
                 len(f"/{KOMODO_SERVICE_ID}")+1 :
             ]
+            if request_url_path_without_service_id.startswith("/"):
+                request_url_path_without_service_id = request_url_path_without_service_id[1:]
             path = f"http://{ready_replica_url}/{request_url_path_without_service_id}"
         else:
             path = f"http://{ready_replica_url}{request.url.path}"

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -729,7 +729,7 @@ class SkyPilotReplicaManager(ReplicaManager):
                              'Skipping syncing down job logs.')
                 return
             assert isinstance(handle, backends.CloudVmRayResourceHandle)
-            replica_job_logs_dir = os.path.join(constants.SKY_LOGS_DIRECTORY,
+            replica_job_logs_dir = os.path.join(serve_constants.LOGS_DIR,
                                                 'replica_jobs')
             job_log_file_name = (
                 controller_utils.download_and_stream_latest_job_log(
@@ -871,7 +871,7 @@ class SkyPilotReplicaManager(ReplicaManager):
                     # Teardown after update replica info since
                     # _terminate_replica will update the replica info too.
                     self._terminate_replica(replica_id,
-                                            sync_down_logs=True,
+                                            sync_down_logs=False,
                                             replica_drain_delay_seconds=0)
         for replica_id, p in list(self._down_process_pool.items()):
             if not p.is_alive():
@@ -1001,7 +1001,7 @@ class SkyPilotReplicaManager(ReplicaManager):
                     f'Service job for replica {info.replica_id} FAILED. '
                     'Terminating...')
                 self._terminate_replica(info.replica_id,
-                                        sync_down_logs=True,
+                                        sync_down_logs=False,
                                         replica_drain_delay_seconds=0)
 
     def _job_status_fetcher(self) -> None:
@@ -1117,7 +1117,7 @@ class SkyPilotReplicaManager(ReplicaManager):
                                                   info.replica_id, info)
                 if should_teardown:
                     self._terminate_replica(info.replica_id,
-                                            sync_down_logs=True,
+                                            sync_down_logs=False,
                                             replica_drain_delay_seconds=0)
 
     def _replica_prober(self) -> None:

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -363,7 +363,7 @@ def get_services() -> List[Dict[str, Any]]:
     """Get all existing service records."""
     user_id = _get_user_id()
     with engine.connect() as cursor:
-        rows = cursor.execute('SELECT v.max_version, s.id, s.name, s.controller_job_id, s.controller_port, s.load_balancer_port, s.status, s.uptime, s.min_replicas, s.max_replicas, s.resources, s.active_versions FROM services s '
+        rows = cursor.execute('SELECT v.max_version, s.id, s.name, s.controller_job_id, s.controller_port, s.load_balancer_port, s.status, s.uptime, s.replica_policy_min_replicas, s.replica_policy_max_replicas, s.resources, s.active_versions FROM services s '
                               'JOIN ('
                               'SELECT service_id, MAX(version) as max_version'
                               ' FROM version_specs GROUP BY service_id) v '
@@ -379,7 +379,7 @@ def get_service_from_name(service_name: str) -> Optional[Dict[str, Any]]:
     service_id, service_name = _parse_name_values(service_name)
     with engine.connect() as cursor:
         rows = cursor.execute(
-            'SELECT v.max_version, s.id, s.name, s.controller_job_id, s.controller_port, s.load_balancer_port, s.status, s.uptime, s.min_replicas, s.max_replicas, s.resources, s.active_versions FROM services s '
+            'SELECT v.max_version, s.id, s.name, s.controller_job_id, s.controller_port, s.load_balancer_port, s.status, s.uptime, s.replica_policy_min_replicas, s.replica_policy_max_replicas, s.resources, s.active_versions FROM services s '
             'JOIN ('
             'SELECT service_id, MAX(version) as max_version '
             f'FROM version_specs WHERE service_id=\'{service_id}\' GROUP BY service_id) v '

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -444,7 +444,9 @@ def add_or_update_replica(service_name: str, replica_id: int,
         spot = None
         if handle:
             launched_resources: sky.Resources = handle.launched_resources
-            cloud = launched_resources.cloud._REPR.lower() if launched_resources.cloud else None
+            cloud = launched_resources.cloud._REPR.upper() if launched_resources.cloud else None
+            if cloud == 'LAMBDA':
+                cloud = 'LAMBDA_LABS'
             region = launched_resources.region
             zone = launched_resources.zone
             instance_type = launched_resources.instance_type

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -363,7 +363,7 @@ def get_services() -> List[Dict[str, Any]]:
     """Get all existing service records."""
     user_id = _get_user_id()
     with engine.connect() as cursor:
-        rows = cursor.execute('SELECT v.max_version, s.id, s.name, s.controller_job_id, s.controller_port, s.load_balancer_port, s.status, s.uptime, s.replica_policy_min_replicas, s.replica_policy_max_replicas, s.resources, s.active_versions FROM services s '
+        rows = cursor.execute('SELECT v.max_version, s.id, s.name, s.controller_job_id, s.controller_port, s.load_balancer_port, s.status, s.uptime, s.replica_policy_min_replicas, s.replica_policy_max_replicas, s.requested_resources, s.active_versions FROM services s '
                               'JOIN ('
                               'SELECT service_id, MAX(version) as max_version'
                               ' FROM version_specs GROUP BY service_id) v '
@@ -379,7 +379,7 @@ def get_service_from_name(service_name: str) -> Optional[Dict[str, Any]]:
     service_id, service_name = _parse_name_values(service_name)
     with engine.connect() as cursor:
         rows = cursor.execute(
-            'SELECT v.max_version, s.id, s.name, s.controller_job_id, s.controller_port, s.load_balancer_port, s.status, s.uptime, s.replica_policy_min_replicas, s.replica_policy_max_replicas, s.resources, s.active_versions FROM services s '
+            'SELECT v.max_version, s.id, s.name, s.controller_job_id, s.controller_port, s.load_balancer_port, s.status, s.uptime, s.replica_policy_min_replicas, s.replica_policy_max_replicas, s.requested_resources, s.active_versions FROM services s '
             'JOIN ('
             'SELECT service_id, MAX(version) as max_version '
             f'FROM version_specs WHERE service_id=\'{service_id}\' GROUP BY service_id) v '

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -458,7 +458,7 @@ def add_or_update_replica(service_name: str, replica_id: int,
         query = """\
         INSERT INTO replicas
         (service_id, replica_id, replica_info, skypilot_cluster_id, cloud, region, zone, instance_type, accelerators, ports, disk_size, spot)
-        VALUES (%s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %d, %s)
         ON CONFLICT (service_id, replica_id)
         DO UPDATE SET replica_info=EXCLUDED.replica_info,
                       skypilot_cluster_id=EXCLUDED.skypilot_cluster_id,
@@ -469,7 +469,7 @@ def add_or_update_replica(service_name: str, replica_id: int,
                       accelerators=EXCLUDED.accelerators,
                       ports=EXCLUDED.ports,
                       disk_size=EXCLUDED.disk_size,
-                      spot=EXCLUDED.spot,
+                      spot=EXCLUDED.spot
                       """
         cursor.execute(query, (service_id, replica_id, ri, replica_info.cluster_name, cloud, region, zone, instance_type, accelerators, ports, disk_size, spot))
 

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -244,9 +244,8 @@ def _get_user_id():
     return user_id
 
 def _parse_name_values(full_name: str):
-    parts = full_name.split('_')
-    service_id = parts[0]
-    name = '_'.join(parts[1:])
+    service_id = full_name
+    name = os.environ['SERVICE_NAME']
 
     return service_id, name
 
@@ -422,7 +421,7 @@ def get_glob_service_names(
                 rows.extend(
                     cursor.execute(
                         f'SELECT id,name FROM services WHERE id=\'{service_id}\' AND user_id = \'{user_id}\'').fetchall())
-    return list({f'{row[0]}_{row[1]}' for row in rows})
+    return list({row[0] for row in rows})
 
 
 # === Replica functions ===

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -458,7 +458,7 @@ def add_or_update_replica(service_name: str, replica_id: int,
         query = """\
         INSERT INTO replicas
         (service_id, replica_id, replica_info, skypilot_cluster_id, cloud, region, zone, instance_type, accelerators, ports, disk_size, spot)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %d, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (service_id, replica_id)
         DO UPDATE SET replica_info=EXCLUDED.replica_info,
                       skypilot_cluster_id=EXCLUDED.skypilot_cluster_id,

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -14,6 +14,7 @@ import typing
 from typing import (Any, Callable, DefaultDict, Dict, Generic, Iterator, List,
                     Optional, TextIO, Type, TypeVar)
 import uuid
+import sys
 
 import colorama
 import filelock
@@ -41,8 +42,9 @@ if typing.TYPE_CHECKING:
 SKY_SERVE_CONTROLLER_NAME: str = (
     f'sky-serve-controller-{common_utils.get_user_hash()}')
 _SYSTEM_MEMORY_GB = psutil.virtual_memory().total // (1024**3)
-NUM_SERVICE_THRESHOLD = (_SYSTEM_MEMORY_GB //
-                         constants.CONTROLLER_MEMORY_USAGE_GB)
+NUM_SERVICE_THRESHOLD = sys.maxsize
+# NUM_SERVICE_THRESHOLD = (_SYSTEM_MEMORY_GB //
+#                          constants.CONTROLLER_MEMORY_USAGE_GB)
 _CONTROLLER_URL = 'http://localhost:{CONTROLLER_PORT}'
 
 _SKYPILOT_PROVISION_LOG_PATTERN = r'.*tail -n100 -f (.*provision\.log).*'

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -234,6 +234,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
         else:
             shutil.rmtree(service_dir)
             serve_state.remove_service(service_name)
+            shutil.rmtree(constants.SKYSERVE_METADATA_DIR)
             logger.info(f'Service {service_name} terminated successfully.')
 
         termination_file = os.environ.get('SKYPILOT_SERVICE_TERMINATION_FINISH_SIGNAL_FILE', None)

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -28,6 +28,7 @@ from sky.serve import serve_utils
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
+from sky.constants import SKY_HOME
 
 # Use the explicit logger name so that the logger is under the
 # `sky.serve.service` namespace when executed directly, so as
@@ -234,7 +235,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
         else:
             shutil.rmtree(service_dir)
             serve_state.remove_service(service_name)
-            shutil.rmtree(constants.SKYSERVE_METADATA_DIR)
+            shutil.rmtree(constants.SKY_HOME)
             logger.info(f'Service {service_name} terminated successfully.')
 
         termination_file = os.environ.get('SKYPILOT_SERVICE_TERMINATION_FINISH_SIGNAL_FILE', None)

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -235,8 +235,10 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
         else:
             shutil.rmtree(service_dir)
             serve_state.remove_service(service_name)
+            time.sleep(5)
             if os.path.exists(constants.SKY_HOME):
                 shutil.rmtree(constants.SKY_HOME, ignore_errors=True)
+                time.sleep(1)
                 if os.path.exists(constants.SKY_HOME):
                     logger.warning(f"{constants.SKY_HOME} is not cleaned up.")
             logger.info(f'Service {service_name} terminated successfully.')

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -235,7 +235,10 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
         else:
             shutil.rmtree(service_dir)
             serve_state.remove_service(service_name)
-            shutil.rmtree(constants.SKY_HOME)
+            if os.path.exists(constants.SKY_HOME):
+                shutil.rmtree(constants.SKY_HOME, ignore_errors=True)
+                if os.path.exists(constants.SKY_HOME):
+                    logger.warning(f"{constants.SKY_HOME} is not cleaned up.")
             logger.info(f'Service {service_name} terminated successfully.')
 
         termination_file = os.environ.get('SKYPILOT_SERVICE_TERMINATION_FINISH_SIGNAL_FILE', None)

--- a/sky/serve/terminate_service.py
+++ b/sky/serve/terminate_service.py
@@ -1,0 +1,18 @@
+import argparse
+from sky.serve.serve_utils import terminate_services
+
+def _terminate_service(service_name: str, purge: bool):
+    logs = terminate_services([service_name], purge)
+    print(logs)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Sky Serve Service')
+    parser.add_argument('--service-name',
+                        type=str,
+                        help='Name of the service',
+                        required=True)
+    parser.add_argument('--purge',
+                        action='store_true',
+                        default=False)
+    args = parser.parse_args()
+    _terminate_service(args.service_name, args.purge)

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -162,6 +162,7 @@ install_requires = [
     # <= 3.13 may encounter https://github.com/ultralytics/yolov5/issues/414
     'pyyaml > 3.13, != 5.4.*',
     'requests',
+    'SQLAlchemy >= 1.4.46',
 ]
 
 local_ray = [

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -276,7 +276,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     setup_requires=['wheel'],
     requires_python='>=3.7',
-    install_requires=install_requires,
+    install_requires=install_requires + aws_dependencies,
     extras_require=extras_require,
     entry_points={
         'console_scripts': ['sky = sky.cli:cli'],

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -276,7 +276,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     setup_requires=['wheel'],
     requires_python='>=3.7',
-    install_requires=install_requires + aws_dependencies,
+    install_requires=install_requires + aws_dependencies + local_ray,
     extras_require=extras_require,
     entry_points={
         'console_scripts': ['sky = sky.cli:cli'],

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -4,9 +4,10 @@ import os
 import pathlib
 from typing import Callable, Optional, Union
 
+from sky.constants import SKY_HOME
 from sky.utils import db_utils
 
-_DB_PATH = os.path.expanduser('~/.sky/skylet_config.db')
+_DB_PATH = os.path.expanduser(f'{SKY_HOME}/skylet_config.db')
 os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
 
 _table_created = False

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -20,7 +20,7 @@ SKY_REMOTE_RAY_PORT_DICT_STR = (
     f'"ray_dashboard_port":{SKY_REMOTE_RAY_DASHBOARD_PORT}}}')
 # The file contains the ports of the Ray cluster that SkyPilot launched,
 # i.e. the PORT_DICT_STR above.
-SKY_REMOTE_RAY_PORT_FILE = f'{SKY_HOME}/ray_port.json'
+SKY_REMOTE_RAY_PORT_FILE = '~/sky/ray_port.json'
 SKY_REMOTE_RAY_TEMPDIR = '/tmp/ray_skypilot'
 SKY_REMOTE_RAY_VERSION = '2.9.3'
 

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -20,7 +20,7 @@ SKY_REMOTE_RAY_PORT_DICT_STR = (
     f'"ray_dashboard_port":{SKY_REMOTE_RAY_DASHBOARD_PORT}}}')
 # The file contains the ports of the Ray cluster that SkyPilot launched,
 # i.e. the PORT_DICT_STR above.
-SKY_REMOTE_RAY_PORT_FILE = '~/sky/ray_port.json'
+SKY_REMOTE_RAY_PORT_FILE = '~/.sky/ray_port.json'
 SKY_REMOTE_RAY_TEMPDIR = '/tmp/ray_skypilot'
 SKY_REMOTE_RAY_VERSION = '2.9.3'
 

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -2,6 +2,7 @@
 from packaging import version
 
 import sky
+from sky.constants import SKY_HOME
 
 SKY_LOGS_DIRECTORY = '~/sky_logs'
 SKY_REMOTE_WORKDIR = '~/sky_workdir'
@@ -19,7 +20,7 @@ SKY_REMOTE_RAY_PORT_DICT_STR = (
     f'"ray_dashboard_port":{SKY_REMOTE_RAY_DASHBOARD_PORT}}}')
 # The file contains the ports of the Ray cluster that SkyPilot launched,
 # i.e. the PORT_DICT_STR above.
-SKY_REMOTE_RAY_PORT_FILE = '~/.sky/ray_port.json'
+SKY_REMOTE_RAY_PORT_FILE = f'{SKY_HOME}/ray_port.json'
 SKY_REMOTE_RAY_TEMPDIR = '/tmp/ray_skypilot'
 SKY_REMOTE_RAY_VERSION = '2.9.3'
 
@@ -64,7 +65,7 @@ SKYLET_VERSION = '8'
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.
 SKYLET_LIB_VERSION = 1
-SKYLET_VERSION_FILE = '~/.sky/skylet_version'
+SKYLET_VERSION_FILE = f'{SKY_HOME}/skylet_version'
 
 # `sky spot dashboard`-related
 #

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -18,6 +18,7 @@ import filelock
 import psutil
 
 from sky import sky_logging
+from sky.constants import SKY_HOME
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import db_utils
@@ -28,7 +29,7 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
-_JOB_STATUS_LOCK = '~/.sky/locks/.job_{}.lock'
+_JOB_STATUS_LOCK = f'{SKY_HOME}/locks/.job_{{}}.lock'
 
 
 def _get_lock_path(job_id: int) -> str:
@@ -50,7 +51,7 @@ class JobInfoLoc(enum.IntEnum):
     RESOURCES = 8
 
 
-_DB_PATH = os.path.expanduser('~/.sky/jobs.db')
+_DB_PATH = os.path.expanduser(f'{SKY_HOME}/jobs.db')
 os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
 
 

--- a/sky/skylet/providers/lambda_cloud/node_provider.py
+++ b/sky/skylet/providers/lambda_cloud/node_provider.py
@@ -16,12 +16,13 @@ from ray.autoscaler.tags import TAG_RAY_USER_NODE_TYPE
 
 from sky import authentication as auth
 from sky.clouds.utils import lambda_utils
+from sky.constants import SKY_HOME
 from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
-_TAG_PATH_PREFIX = '~/.sky/generated/lambda_cloud/metadata'
+_TAG_PATH_PREFIX = f'{SKY_HOME}/generated/lambda_cloud/metadata'
 _REMOTE_SSH_KEY_NAME = '~/.lambda_cloud/ssh_key_name'
 _REMOTE_RAY_SSH_KEY = '~/ray_bootstrap_key.pem'
 _REMOTE_RAY_YAML = '~/ray_bootstrap_config.yaml'

--- a/sky/skylet/providers/scp/node_provider.py
+++ b/sky/skylet/providers/scp/node_provider.py
@@ -27,10 +27,11 @@ from ray.autoscaler.tags import TAG_RAY_USER_NODE_TYPE
 
 from sky.clouds.utils import scp_utils
 from sky.clouds.utils.scp_utils import SCPCreationFailError
+from sky.constants import SKY_HOME
 from sky.skylet.providers.scp.config import ZoneConfig
 from sky.utils import common_utils
 
-TAG_PATH_PREFIX = '~/.sky/generated/scp/metadata'
+TAG_PATH_PREFIX = f'{SKY_HOME}/generated/scp/metadata'
 REMOTE_RAY_YAML = '~/ray_bootstrap_config.yaml'
 
 logger = logging.getLogger(__name__)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -49,6 +49,7 @@ from typing import Any, Dict, Iterable, Optional
 import yaml
 
 from sky import sky_logging
+from sky.constants import SKY_HOME
 from sky.utils import common_utils
 from sky.utils import schemas
 from sky.utils import ux_utils
@@ -68,7 +69,7 @@ from sky.utils import ux_utils
 ENV_VAR_SKYPILOT_CONFIG = 'SKYPILOT_CONFIG'
 
 # Path to the local config file.
-CONFIG_PATH = '~/.sky/config.yaml'
+CONFIG_PATH = f'{SKY_HOME}/config.yaml'
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/spot/constants.py
+++ b/sky/spot/constants.py
@@ -1,9 +1,10 @@
 """Constants used for Managed Spot."""
+from sky.constants import SKY_HOME
 
 SPOT_CONTROLLER_TEMPLATE = 'spot-controller.yaml.j2'
-SPOT_CONTROLLER_YAML_PREFIX = '~/.sky/spot_controller'
+SPOT_CONTROLLER_YAML_PREFIX = f'{SKY_HOME}/spot_controller'
 
-SPOT_TASK_YAML_PREFIX = '~/.sky/spot_tasks'
+SPOT_TASK_YAML_PREFIX = f'{SKY_HOME}/spot_tasks'
 
 # Resources as a dict for the spot controller.
 # Use default CPU instance type for spot controller with >= 24GB, i.e.

--- a/sky/spot/dashboard/dashboard.py
+++ b/sky/spot/dashboard/dashboard.py
@@ -14,6 +14,7 @@ import yaml
 
 import sky
 from sky import spot
+from sky.constants import SKY_HOME
 from sky.utils import common_utils
 
 app = flask.Flask(__name__)
@@ -24,9 +25,9 @@ def _is_running_on_spot_controller() -> bool:
 
     Loads ~/.sky/sky_ray.yml and check cluster_name.
     """
-    if pathlib.Path('~/.sky/sky_ray.yml').expanduser().exists():
+    if pathlib.Path(f'{SKY_HOME}/sky_ray.yml').expanduser().exists():
         config = yaml.safe_load(
-            pathlib.Path('~/.sky/sky_ray.yml').expanduser().read_text())
+            pathlib.Path(f'{SKY_HOME}/sky_ray.yml').expanduser().read_text())
         return config.get('cluster_name', '').startswith('sky-spot-controller-')
     return False
 

--- a/sky/spot/spot_state.py
+++ b/sky/spot/spot_state.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import colorama
 
 from sky import sky_logging
+from sky.constants import SKY_HOME
 from sky.utils import db_utils
 
 if typing.TYPE_CHECKING:
@@ -20,7 +21,7 @@ CallbackType = Callable[[str], None]
 
 logger = sky_logging.init_logger(__name__)
 
-_DB_PATH = pathlib.Path('~/.sky/spot_jobs.db')
+_DB_PATH = pathlib.Path(f'{SKY_HOME}/spot_jobs.db')
 _DB_PATH = _DB_PATH.expanduser().absolute()
 _DB_PATH.parents[0].mkdir(parents=True, exist_ok=True)
 _DB_PATH = str(_DB_PATH)

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -18,6 +18,7 @@ from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
 from sky.backends import backend_utils
+from sky.constants import SKY_HOME
 from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.skylet.log_lib import run_bash_command_with_log
@@ -45,7 +46,7 @@ JOB_STATUS_CHECK_GAP_SECONDS = 20
 # Controller checks if its job has started every this many seconds.
 JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 5
 
-_SPOT_STATUS_CACHE = '~/.sky/spot_status_cache.txt'
+_SPOT_STATUS_CACHE = f'{SKY_HOME}/spot_status_cache.txt'
 
 _LOG_STREAM_CHECK_CONTROLLER_GAP_SECONDS = 5
 

--- a/sky/usage/constants.py
+++ b/sky/usage/constants.py
@@ -1,10 +1,11 @@
 """Constants for usage collection."""
+from sky.constants import SKY_HOME
 
 LOG_URL = 'http://usage.skypilot.co:9090/loki/api/v1/push'  # pylint: disable=line-too-long
 
 USAGE_MESSAGE_SCHEMA_VERSION = 1
 
-PRIVACY_POLICY_PATH = '~/.sky/privacy_policy'
+PRIVACY_POLICY_PATH = f'{SKY_HOME}/privacy_policy'
 
 USAGE_POLICY_MESSAGE = (
     'SkyPilot collects usage data to improve its services. '

--- a/sky/utils/cluster_yaml_utils.py
+++ b/sky/utils/cluster_yaml_utils.py
@@ -6,7 +6,7 @@ from sky.constants import SKY_HOME
 
 # The cluster yaml used to create the current cluster where the module is
 # called.
-SKY_CLUSTER_YAML_REMOTE_PATH = '~/sky/sky_ray.yml'
+SKY_CLUSTER_YAML_REMOTE_PATH = '~/.sky/sky_ray.yml'
 
 
 def get_provider_name(config: dict) -> str:

--- a/sky/utils/cluster_yaml_utils.py
+++ b/sky/utils/cluster_yaml_utils.py
@@ -2,9 +2,11 @@
 
 import re
 
+from sky.constants import SKY_HOME
+
 # The cluster yaml used to create the current cluster where the module is
 # called.
-SKY_CLUSTER_YAML_REMOTE_PATH = '~/.sky/sky_ray.yml'
+SKY_CLUSTER_YAML_REMOTE_PATH = f'{SKY_HOME}/sky_ray.yml'
 
 
 def get_provider_name(config: dict) -> str:

--- a/sky/utils/cluster_yaml_utils.py
+++ b/sky/utils/cluster_yaml_utils.py
@@ -6,7 +6,7 @@ from sky.constants import SKY_HOME
 
 # The cluster yaml used to create the current cluster where the module is
 # called.
-SKY_CLUSTER_YAML_REMOTE_PATH = f'{SKY_HOME}/sky_ray.yml'
+SKY_CLUSTER_YAML_REMOTE_PATH = '~/sky/sky_ray.yml'
 
 
 def get_provider_name(config: dict) -> str:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -68,6 +68,10 @@ def get_user_hash() -> str:
     We cache the user hash in a file to avoid potential user_name or
     hostname changes causing a new user hash to be generated.
     """
+    hash_str = os.environ.get('SKYPILOT_USER_HASH_STR', None)
+    if hash_str:
+        user_hash = hashlib.md5(hash_str.encode()).hexdigest()[:USER_HASH_LENGTH]
+        return user_hash
 
     def _is_valid_user_hash(user_hash: Optional[str]) -> bool:
         if user_hash is None:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -23,11 +23,12 @@ import yaml
 
 from sky import exceptions
 from sky import sky_logging
+from sky.constants import SKY_HOME
 from sky.skylet import constants
 from sky.utils import ux_utils
 from sky.utils import validator
 
-_USER_HASH_FILE = os.path.expanduser('~/.sky/user_hash')
+_USER_HASH_FILE = os.path.expanduser(f'{SKY_HOME}/user_hash')
 USER_HASH_LENGTH = 8
 USER_HASH_LENGTH_IN_CLUSTER_NAME = 4
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -17,6 +17,7 @@ from sky import resources
 from sky import sky_logging
 from sky import skypilot_config
 from sky.clouds import gcp
+from sky.constants import SKY_HOME
 from sky.data import data_utils
 from sky.data import storage as storage_lib
 from sky.serve import serve_utils
@@ -36,7 +37,7 @@ logger = sky_logging.init_logger(__name__)
 # controller resources spec.
 CONTROLLER_RESOURCES_NOT_VALID_MESSAGE = (
     '{controller_type} controller resources is not valid, please check '
-    '~/.sky/config.yaml file and make sure '
+    f'{SKY_HOME}/config.yaml file and make sure '
     '{controller_type}.controller.resources is a valid resources spec. '
     'Details:\n  {err}')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Delete `SKY_HOME` after the service is terminated. The `rmtree` call on on the previous line removes `service_dir` which is defined here: https://github.com/komodoai/skypilot/blob/6368df16402fa0ee7bd4b3b0e56f3038ae61d21a/sky/serve/service.py#L160
by a function call to `generate_remote_service_dir_name`: https://github.com/komodoai/skypilot/blob/6368df16402fa0ee7bd4b3b0e56f3038ae61d21a/sky/serve/serve_utils.py#L190 so what ends up being deleted is `{SKY_HOME}/serve/service-id`, this PR will also delete `SKY_HOME` itself after the service is removed from db.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
