### PR TITLE
feat: don't run load balancer as part of a service pod

### DIFF
--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -171,18 +171,10 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
         service_name, constants.INITIAL_VERSION)
     shutil.copy(tmp_task_yaml, task_yaml)
 
-    # Generate load balancer log file name.
-    # load_balancer_log_file = os.path.expanduser(
-    #     serve_utils.generate_remote_load_balancer_log_file_name(service_name))
-
-    # Don't launch load_balancer process
     controller_process = None
-    # load_balancer_process = None
     try:
         with filelock.FileLock(
                 os.path.expanduser(constants.PORT_SELECTION_FILE_LOCK_PATH)):
-            # controller_port = common_utils.find_free_port(
-            #     constants.CONTROLLER_PORT_START)
             controller_port = 8000
             # Start the controller.
             controller_process = multiprocessing.Process(
@@ -193,21 +185,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
                                                     controller_port)
 
             # TODO(tian): Support HTTPS.
-            # controller_addr = f'http://localhost:{controller_port}'
-            # load_balancer_port = common_utils.find_free_port(
-            #     constants.LOAD_BALANCER_PORT_START)
             load_balancer_port = 8000
-
-            # Start the load balancer.
-            # TODO(tian): Probably we could enable multiple ports specified in
-            # service spec and we could start multiple load balancers.
-            # After that, we will have a mapping from replica port to endpoint.
-            # load_balancer_process = multiprocessing.Process(
-            #     target=ux_utils.RedirectOutputForProcess(
-            #         load_balancer.run_load_balancer,
-            #         load_balancer_log_file).run,
-            #     args=(controller_addr, load_balancer_port))
-            # load_balancer_process.start()
             serve_state.set_service_load_balancer_port(service_name,
                                                        load_balancer_port)
 
@@ -219,8 +197,6 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
             service_name, serve_state.ServiceStatus.SHUTTING_DOWN)
     finally:
         process_to_kill: List[multiprocessing.Process] = []
-        # if load_balancer_process is not None:
-        #     process_to_kill.append(load_balancer_process)
         if controller_process is not None:
             process_to_kill.append(controller_process)
         # Kill load balancer process first since it will raise errors if failed

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -172,16 +172,18 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
     shutil.copy(tmp_task_yaml, task_yaml)
 
     # Generate load balancer log file name.
-    load_balancer_log_file = os.path.expanduser(
-        serve_utils.generate_remote_load_balancer_log_file_name(service_name))
+    # load_balancer_log_file = os.path.expanduser(
+    #     serve_utils.generate_remote_load_balancer_log_file_name(service_name))
 
+    # Don't launch load_balancer process
     controller_process = None
-    load_balancer_process = None
+    # load_balancer_process = None
     try:
         with filelock.FileLock(
                 os.path.expanduser(constants.PORT_SELECTION_FILE_LOCK_PATH)):
-            controller_port = common_utils.find_free_port(
-                constants.CONTROLLER_PORT_START)
+            # controller_port = common_utils.find_free_port(
+            #     constants.CONTROLLER_PORT_START)
+            controller_port = 8000
             # Start the controller.
             controller_process = multiprocessing.Process(
                 target=controller.run_controller,
@@ -191,20 +193,21 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
                                                     controller_port)
 
             # TODO(tian): Support HTTPS.
-            controller_addr = f'http://localhost:{controller_port}'
-            load_balancer_port = common_utils.find_free_port(
-                constants.LOAD_BALANCER_PORT_START)
+            # controller_addr = f'http://localhost:{controller_port}'
+            # load_balancer_port = common_utils.find_free_port(
+            #     constants.LOAD_BALANCER_PORT_START)
+            load_balancer_port = 8000
 
             # Start the load balancer.
             # TODO(tian): Probably we could enable multiple ports specified in
             # service spec and we could start multiple load balancers.
             # After that, we will have a mapping from replica port to endpoint.
-            load_balancer_process = multiprocessing.Process(
-                target=ux_utils.RedirectOutputForProcess(
-                    load_balancer.run_load_balancer,
-                    load_balancer_log_file).run,
-                args=(controller_addr, load_balancer_port))
-            load_balancer_process.start()
+            # load_balancer_process = multiprocessing.Process(
+            #     target=ux_utils.RedirectOutputForProcess(
+            #         load_balancer.run_load_balancer,
+            #         load_balancer_log_file).run,
+            #     args=(controller_addr, load_balancer_port))
+            # load_balancer_process.start()
             serve_state.set_service_load_balancer_port(service_name,
                                                        load_balancer_port)
 
@@ -216,8 +219,8 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
             service_name, serve_state.ServiceStatus.SHUTTING_DOWN)
     finally:
         process_to_kill: List[multiprocessing.Process] = []
-        if load_balancer_process is not None:
-            process_to_kill.append(load_balancer_process)
+        # if load_balancer_process is not None:
+        #     process_to_kill.append(load_balancer_process)
         if controller_process is not None:
             process_to_kill.append(controller_process)
         # Kill load balancer process first since it will raise errors if failed


### PR DESCRIPTION
Service pod now just runs a controller, load balancer is launched separately.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
